### PR TITLE
Updates hidapi to 1.2 and libperif to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "hidapi"
-version = "1.1.0"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -529,10 +529,10 @@ dependencies = [
 
 [[package]]
 name = "libperif"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hidapi 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hidapi 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -703,7 +703,7 @@ dependencies = [
  "glib 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtk 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "last-git-commit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libperif 0.2.0",
+ "libperif 0.3.0",
  "notify-rust 3.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -983,7 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gobject-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31d1a804f62034eccf370006ccaef3708a71c31d561fee88564abe71177553d9"
 "checksum gtk 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cd1d646cc9a2cb795f33b538779a3f22e71dc172f2aba08a41e84a2f72c0dec"
 "checksum gtk-sys 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53def660c7b48b00b510c81ef2d2fbd3c570f1527081d8d7947f471513e1a4c1"
-"checksum hidapi 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44780b6eb6a4209b4f212193af3f40e4163302e26c3753abe688f54c0e39380f"
+"checksum hidapi 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5c6ffb97f2ec5835ec73bcea5256fc2cd57a13c5958230778ef97f11900ba661"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum last-git-commit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e93701437f23216dc215edcbee3c804246abf2397891d90eadfbb0f1790642c"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"

--- a/libperif/Cargo.toml
+++ b/libperif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libperif"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Edwin Svensson <git@olback.net>"]
 edition = "2018"
 
@@ -22,7 +22,7 @@ path = "src/bin/list_all_connected.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hidapi = { version = "1.1", default-features = false, features = [ "linux-static-hidraw" ] }
+hidapi = { version = "1.2", default-features = false, features = [ "linux-static-hidraw" ] }
 
 # Needed by src/devices/sony/dualshock4.rs
 crc = "1.8.1"

--- a/libperif/src/bin/list_all_connected.rs
+++ b/libperif/src/bin/list_all_connected.rs
@@ -7,12 +7,12 @@ fn main() {
 
     println!("<manufacturer> <product_string> <vid>:<pid>");
 
-    for dev in hidapi.devices() {
+    for dev in hidapi.device_list() {
 
-        let mfr = dev.manufacturer_string.clone().unwrap_or(String::from("unknown"));
-        let prd = dev.product_string.clone().unwrap_or(String::from("unknown"));
+        let mfr = dev.manufacturer_string().clone().unwrap_or("unknown");
+        let prd = dev.product_string().clone().unwrap_or("unknown");
 
-        println!("{} {} {:04x}:{:04x}", mfr, prd, dev.vendor_id, dev.product_id);
+        println!("{} {} {:04x}:{:04x}", mfr, prd, dev.vendor_id(), dev.product_id());
 
     }
 

--- a/libperif/src/devices/mod.rs
+++ b/libperif/src/devices/mod.rs
@@ -28,18 +28,18 @@ pub fn get_available_devices(hidapi: &mut hidapi::HidApi) -> PerifResult<Vec<Dev
 
     hidapi.refresh_devices()?;
 
-    for hid_dev in hidapi.devices() {
+    for hid_dev in hidapi.device_list() {
         for supported in get_supported_devices() {
-            if hid_dev.vendor_id == supported.vid && hid_dev.product_id == supported.pid {
+            if hid_dev.vendor_id() == supported.vid && hid_dev.product_id() == supported.pid {
                 available.push(Device {
                     name: supported.name,
                     kind: supported.kind,
-                    path: hid_dev.path.clone(),
+                    path: hid_dev.path().to_owned(),
                     vid: supported.vid,
                     pid: supported.pid,
-                    serial: hid_dev.serial_number.clone(),
-                    manufacturer_string: hid_dev.manufacturer_string.clone(),
-                    product_string: hid_dev.product_string.clone(),
+                    serial: hid_dev.serial_number().map_or(None, |s| Some(s.to_owned())),
+                    manufacturer_string: hid_dev.manufacturer_string().map_or(None, |s| Some(s.to_owned())),
+                    product_string: hid_dev.product_string().map_or(None, |s| Some(s.to_owned())),
                     get_battery: supported.get_battery,
                     set_lightning: supported.set_lightning,
                     set_sidetone: supported.set_sidetone,


### PR DESCRIPTION
This PR updates the `hidapi` crate to its current minor version, v1.2, and correspondingly bumps the version number of `libperif` to v0.3.